### PR TITLE
Add additional diff format options

### DIFF
--- a/lib/rewrite/source.ex
+++ b/lib/rewrite/source.ex
@@ -586,6 +586,8 @@ defmodule Rewrite.Source do
   @doc ~S'''
   Returns iodata showing all diffs of the given `source`.
 
+  See `Rewrite.TextDiff.format/3` for options.
+
   ## Examples
 
       iex> code = """

--- a/lib/rewrite/text_diff.ex
+++ b/lib/rewrite/text_diff.ex
@@ -44,21 +44,21 @@ defmodule Rewrite.TextDiff do
 
   @newline "\n"
   @blank " "
-
-  @separator "|"
-  @cr "↵"
   @line_num_pad @blank
+  @cr "↵"
 
-  @gutter [
-    del: " - ",
-    eq: "   ",
-    ins: " + ",
-    skip: "..."
-  ]
-
-  @colors [
-    del: [text: :red, space: :red_background],
-    ins: [text: :green, space: :green_background]
+  @format [
+    separator: "|",
+    gutter: [
+      del: " - ",
+      eq: "   ",
+      ins: " + ",
+      skip: "..."
+    ],
+    colors: [
+      del: [text: :red, space: :red_background],
+      ins: [text: :green, space: :green_background]
+    ]
   ]
 
   @default_opts [
@@ -66,7 +66,8 @@ defmodule Rewrite.TextDiff do
     before: 2,
     color: true,
     line: 1,
-    line_numbers: true
+    line_numbers: true,
+    format: @format
   ]
 
   @doc ~S'''
@@ -75,7 +76,7 @@ defmodule Rewrite.TextDiff do
   The returned `iodata` shows the lines with changes and 2 lines before and
   after the changed positions. The string contains also a gutter with line
   number and a `-` or `+` for removed and added lines. Multiple lines without
-  changes are marke with `...` in the gutter.
+  changes are marked with `...` in the gutter.
 
   ## Options
 
@@ -252,7 +253,7 @@ defmodule Rewrite.TextDiff do
         ""
       end
 
-    [[line_num, @gutter[:skip], @separator, @newline] | iodata]
+    [[line_num, opts[:format][:gutter][:skip], opts[:format][:separator], @newline] | iodata]
   end
 
   defp lines(iodata, {:chg, del, ins}, line_nums, opts) do
@@ -277,8 +278,8 @@ defmodule Rewrite.TextDiff do
   defp gutter(line_nums, kind, opts) do
     [
       maybe_line_num(line_nums, kind, opts),
-      colorize(@gutter[kind], kind, false, opts),
-      @separator
+      colorize(opts[:format][:gutter][kind], kind, false, opts),
+      opts[:format][:separator]
     ]
   end
 
@@ -336,12 +337,12 @@ defmodule Rewrite.TextDiff do
   end
 
   defp colorize(str, kind, space, opts) do
-    case Keyword.fetch!(opts, :color) && Keyword.has_key?(@colors, kind) do
+    case Keyword.fetch!(opts, :color) && Keyword.has_key?(opts[:format][:colors], kind) do
       false ->
         str
 
       true ->
-        color = Keyword.fetch!(@colors, kind)
+        color = Keyword.fetch!(opts[:format][:colors], kind)
 
         case space do
           false ->

--- a/lib/rewrite/text_diff.ex
+++ b/lib/rewrite/text_diff.ex
@@ -58,7 +58,8 @@ defmodule Rewrite.TextDiff do
     colors: [
       del: [text: :red, space: :red_background],
       ins: [text: :green, space: :green_background],
-      skip: [text: :light_black]
+      skip: [text: :light_black],
+      separator: [text: :light_black]
     ]
   ]
 
@@ -108,6 +109,7 @@ defmodule Rewrite.TextDiff do
       * `:del` - `[text: :red, space: :red_background]`
       * `:ins` - `[text: :green, space: :green_background]`
       * `:skip` - `[text: :light_black]`
+      * `:separator` - `[text: :light_black]`
 
   These top-level formatting options will be merged into passed options. For
   example, you could change only the `:separator` with:
@@ -287,8 +289,9 @@ defmodule Rewrite.TextDiff do
       end
 
     gutter = colorize(opts[:format][:gutter][:skip], :skip, false, opts)
+    separator = colorize(opts[:format][:separator], :separator, false, opts)
 
-    [[line_num, gutter, opts[:format][:separator], @newline] | iodata]
+    [[line_num, gutter, separator, @newline] | iodata]
   end
 
   defp lines(iodata, {:chg, del, ins}, line_nums, opts) do
@@ -314,7 +317,7 @@ defmodule Rewrite.TextDiff do
     [
       maybe_line_num(line_nums, kind, opts),
       colorize(opts[:format][:gutter][kind], kind, false, opts),
-      opts[:format][:separator]
+      colorize(opts[:format][:separator], :separator, false, opts)
     ]
   end
 

--- a/test/rewrite/text_diff_test.exs
+++ b/test/rewrite/text_diff_test.exs
@@ -386,6 +386,41 @@ defmodule Rewrite.TextDiffTest do
 
       assert to_binary(old, new, color: false) == exp
     end
+
+    test "omits line numbers when :line_numbers is false" do
+      old = """
+      aaa
+      bbb
+      ccc
+      ddd
+      eee
+      fff
+      ggg
+      """
+
+      new = """
+      aaa
+      bbb
+      ccc
+      eee
+      fff
+      ggg
+      """
+
+      exp = """
+      ...|
+         |bbb
+         |ccc
+       - |ddd
+         |eee
+         |fff
+      ...|
+      """
+
+      assert TextDiff.format(old, new, line_numbers: false)
+
+      assert to_binary(old, new, color: false, line_numbers: false) == exp
+    end
   end
 
   defp to_binary(old, new, opts \\ []) do

--- a/test/rewrite/text_diff_test.exs
+++ b/test/rewrite/text_diff_test.exs
@@ -18,7 +18,8 @@ defmodule Rewrite.TextDiffTest do
       assert output = to_binary(old, new)
 
       if IO.ANSI.enabled?() do
-        assert output == "1  \e[31m - \e[0m|\e[31mdel\e[0m\n  1\e[32m + \e[0m|\n"
+        assert output ==
+                 "1  \e[31m - \e[0m\e[90m|\e[0m\e[31mdel\e[0m\n  1\e[32m + \e[0m\e[90m|\e[0m\n"
       end
 
       assert to_binary(old, new, color: false) == """
@@ -35,8 +36,8 @@ defmodule Rewrite.TextDiffTest do
 
       if IO.ANSI.enabled?() do
         assert output == """
-               1  \e[31m - \e[0m|one three\e[31m\e[0m\e[41m \e[0m\e[31mtwo\e[0m
-                 1\e[32m + \e[0m|one t\e[32mwo\e[0m\e[42m \e[0m\e[32mt\e[0mhree
+               1  \e[31m - \e[0m\e[90m|\e[0mone three\e[31m\e[0m\e[41m \e[0m\e[31mtwo\e[0m
+                 1\e[32m + \e[0m\e[90m|\e[0mone t\e[32mwo\e[0m\e[42m \e[0m\e[32mt\e[0mhree
                """
       end
 
@@ -498,9 +499,10 @@ defmodule Rewrite.TextDiffTest do
       opts = [
         format: [
           colors: [
-            skip: [text: :light_black],
             ins: [text: :blue],
-            del: [text: :magenta]
+            del: [text: :magenta],
+            skip: [text: :light_black],
+            separator: [text: :light_black]
           ]
         ],
         before: 1,
@@ -511,7 +513,7 @@ defmodule Rewrite.TextDiffTest do
 
       if IO.ANSI.enabled?() do
         assert to_binary(old, new, opts) ==
-                 "   \e[90m...\e[0m|\n2 2   |bbb\n3  \e[35m - \e[0m|\e[35mccc\e[0m\n  3\e[34m + \e[0m|\e[34mxxx\e[0m\n4 4   |ddd\n   \e[90m...\e[0m|\n"
+                 "   \e[90m...\e[0m\e[90m|\e[0m\n2 2   \e[90m|\e[0mbbb\n3  \e[35m - \e[0m\e[90m|\e[0m\e[35mccc\e[0m\n  3\e[34m + \e[0m\e[90m|\e[0m\e[34mxxx\e[0m\n4 4   \e[90m|\e[0mddd\n   \e[90m...\e[0m\e[90m|\e[0m\n"
       end
     end
   end


### PR DESCRIPTION
(Note that this PR branches off of #7)

This PR does the following:

* Refactors diff formatting to access format constants and colors through the opts, allowing the user to customize the gutter, separator, and colors.
* Adds a default color for the `:skip` gutter and `:separator` (`:light_black`, which should render subdued).
* Refactors `colorize/4` helper to make the `:space` color optional (it would previously throw an error from `IO.ANSI.format`).