### PR TITLE
Perform basic tokenization when diffing a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## Unreleased
+
++ Update `Rewrite.TextDiff.format/3` to include more formatting customization.
+
 ## 0.3.0 - 2022/12/10
 
-+ Accept glob as `%GLobEx{}` as argument for `Rewrite.Project.read!/1`
++ Accept glob as `%GlobEx{}` as argument for `Rewrite.Project.read!/1`
 
 ## 0.2.0 - 2022/09/08
 

--- a/lib/rewrite/text_diff.ex
+++ b/lib/rewrite/text_diff.ex
@@ -468,7 +468,7 @@ defmodule Rewrite.TextDiff do
   defp tokenize(line, fun) when is_function(fun, 1), do: fun.(line)
 
   defp tokenize(line, {m, f, a}) when is_atom(m) and is_atom(f) and is_list(a) do
-    apply(m, f, [line] ++ a)
+    apply(m, f, [line | a])
   end
 
   @doc false

--- a/lib/rewrite/text_diff.ex
+++ b/lib/rewrite/text_diff.ex
@@ -371,7 +371,7 @@ defmodule Rewrite.TextDiff do
       str = IO.iodata_to_binary(iodata)
 
       case op do
-        :eq -> {[del | str], [ins | str]}
+        :eq -> {[del | iodata], [ins | iodata]}
         :del -> {[del | colorize(str, :del, true, opts)], ins}
         :ins -> {del, [ins | colorize(str, :ins, true, opts)]}
       end

--- a/test/rewrite/text_diff_test.exs
+++ b/test/rewrite/text_diff_test.exs
@@ -36,8 +36,8 @@ defmodule Rewrite.TextDiffTest do
 
       if IO.ANSI.enabled?() do
         assert output == """
-               1  \e[31m - \e[0m\e[90m|\e[0mone three\e[31m\e[0m\e[41m \e[0m\e[31mtwo\e[0m
-                 1\e[32m + \e[0m\e[90m|\e[0mone t\e[32mwo\e[0m\e[42m \e[0m\e[32mt\e[0mhree
+               1  \e[31m - \e[0m\e[90m|\e[0mone \e[31mthree\e[0m\e[41m \e[0m\e[31m\e[0mtwo
+                 1\e[32m + \e[0m\e[90m|\e[0mone two\e[32m\e[0m\e[42m \e[0m\e[32mthree\e[0m
                """
       end
 

--- a/test/rewrite/text_diff_test.exs
+++ b/test/rewrite/text_diff_test.exs
@@ -516,6 +516,27 @@ defmodule Rewrite.TextDiffTest do
                  "   \e[90m...\e[0m\e[90m|\e[0m\n2 2   \e[90m|\e[0mbbb\n3  \e[35m - \e[0m\e[90m|\e[0m\e[35mccc\e[0m\n  3\e[34m + \e[0m\e[90m|\e[0m\e[34mxxx\e[0m\n4 4   \e[90m|\e[0mddd\n   \e[90m...\e[0m\e[90m|\e[0m\n"
       end
     end
+
+    test "accepts alternate :tokenizer" do
+      for opts <- [[tokenizer: &String.graphemes/1], [tokenizer: {String, :graphemes, []}]] do
+        old = "one three two"
+        new = "one two three"
+
+        assert output = to_binary(old, new, opts)
+
+        if IO.ANSI.enabled?() do
+          assert output == """
+                 1  \e[31m - \e[0m\e[90m|\e[0mone three\e[31m\e[0m\e[41m \e[0m\e[31mtwo\e[0m
+                   1\e[32m + \e[0m\e[90m|\e[0mone t\e[32mwo\e[0m\e[42m \e[0m\e[32mt\e[0mhree
+                 """
+        end
+
+        assert to_binary(old, new, [color: false] ++ opts) == """
+               1   - |one three two
+                 1 + |one two three
+               """
+      end
+    end
   end
 
   defp to_binary(old, new, opts \\ []) do


### PR DESCRIPTION
This PR adds _extremely basic_ tokenization when diffing a single line, which prioritizes highlighting entire words as opposed to individual characters.

|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/503938/215232851-5d35face-8a09-4282-89f0-0258b68b1223.jpg)|![after](https://user-images.githubusercontent.com/503938/215232856-27c25458-9b6a-4c4d-b6a1-7f006e68159c.jpg)|

The "tokenization" used here is a very simple regex that splits the line on anything that isn't alphanumeric or `_`. The `include_captures: true` option is used to retain the text being split on. An example:

```elixir
iex> tokenize("  defp tokenize(line) do")
["  ", "defp", " ", "tokenize", "(", "line", ")", " ", "do"]
```

`List.myers_difference` is then used to generate the diff instead of `String.myers_difference`, which operated character-by-character.