### PR TITLE
Add `Rewrite.Source.put_private/3` (resolves #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 0.4.2 - unreleased
+## Unreleased
 
-+ Unpin `sourceror`.
++ Update `sourceror` to ~> 0.12.
++ Add `Rewrite.Source.put_private/3`, which allows for storing arbitrary data
+  on a source.
 
 ## 0.4.2 - 2023/02/05
 

--- a/lib/rewrite/source.ex
+++ b/lib/rewrite/source.ex
@@ -24,7 +24,8 @@ defmodule Rewrite.Source do
     :modules,
     :owner,
     updates: [],
-    issues: []
+    issues: [],
+    private: %{}
   ]
 
   @typedoc """
@@ -53,7 +54,8 @@ defmodule Rewrite.Source do
           updates: [{kind(), by(), String.t()}],
           issues: [issue()],
           from: from(),
-          owner: module()
+          owner: module(),
+          private: map()
         }
 
   @doc ~S'''
@@ -246,6 +248,26 @@ defmodule Rewrite.Source do
   """
   @spec add_issue(t(), issue()) :: t()
   def add_issue(%Source{} = source, issue), do: add_issues(source, [issue])
+
+  @doc """
+  Assigns a private `key` and `value` to the `source`.
+
+  This is not used or accessed by Rewrite, but is intended as private storage
+  for users or libraries that wish to store additional data about a source.
+
+  ## Examples
+
+      iex> source =
+      ...>   "a + b"
+      ...>   |> Source.from_string()
+      ...>   |> Source.put_private(:origin, :example)
+      iex> source.private[:origin]
+      :example
+  """
+  @spec put_private(t(), key :: term(), value :: term()) :: t()
+  def put_private(%Source{} = source, key, value) do
+    Map.update!(source, :private, &Map.put(&1, key, value))
+  end
 
   @doc ~S"""
   Updates the `code` or the `path` of a `source`.

--- a/mix.lock
+++ b/mix.lock
@@ -19,7 +19,7 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "sourceror": {:hex, :sourceror, "0.11.2", "549ce48be666421ac60cfb7f59c8752e0d393baa0b14d06271d3f6a8c1b027ab", [:mix], [], "hexpm", "9ab659118896a36be6eec68ff7b0674cba372fc8e210b1e9dc8cf2b55bb70dfb"},
+  "sourceror": {:hex, :sourceror, "0.12.0", "b0a43f9b91d69fead8ffa307e203fadaf30001d8c2643f597518dd9508d6b32d", [:mix], [], "hexpm", "67dcc48a4d4bb8c397ad0b86cf0d4667e1b50ffdf31cda585524640d1caded85"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/rewrite/source_test.exs
+++ b/test/rewrite/source_test.exs
@@ -244,6 +244,15 @@ defmodule Rewrite.SourceTest do
     end
   end
 
+  describe "put_private/3" do
+    test "updates the private map" do
+      source = Source.from_string("a + b\n")
+
+      assert source = Source.put_private(source, :any_key, :any_value)
+      assert source.private[:any_key] == :any_value
+    end
+  end
+
   defp hash(path, code), do: :crypto.hash(:md5, path <> code)
 
   defp assert_source(%Source{} = source, expected) do
@@ -254,6 +263,7 @@ defmodule Rewrite.SourceTest do
     assert source.modules == expected.modules
     assert source.updates == Map.get(expected, :updates, [])
     assert source.issues == Map.get(expected, :issues, [])
+    assert source.private == Map.get(expected, :private, %{})
 
     if Map.has_key?(expected, :ast) do
       assert source.ast == expected.ast


### PR DESCRIPTION
See #6 for prior discussion.

@NickNeck, I opted to call this `put_private` because I think it's more consistent with similar APIs elsewhere in the Elixir ecosystem and I think it's more obvious what it means/does, but if you'd prefer it to be called something else, I'm happy to edit & rebase.

Also, I noticed that after Sourceror was unpinned in a4deca4, the `mix.lock` wasn't updated and mix didn't let me run tests without updating it, so I've included that in this PR.