### PR TITLE
Fix the module concat problem when ast is encountered

### DIFF
--- a/lib/rewrite/source.ex
+++ b/lib/rewrite/source.ex
@@ -662,6 +662,7 @@ defmodule Rewrite.Source do
     end)
     |> elem(1)
     |> Enum.uniq()
+    |> Enum.filter(&is_atom/1)
   end
 
   defp format(ast, file \\ nil) do
@@ -704,6 +705,8 @@ defmodule Rewrite.Source do
   end
 
   defp concat({:__aliases__, _meta, module}), do: Module.concat(module)
+
+  defp concat(ast), do: ast
 
   defp hash(nil, code), do: :crypto.hash(:md5, code)
 

--- a/test/fixtures/source/module_ast_contained.ex
+++ b/test/fixtures/source/module_ast_contained.ex
@@ -1,0 +1,16 @@
+defmodule ModuleAstContained do
+  def dynamic_module_ast() do
+    module_name = DynamicModule
+
+    ast =
+      quote do
+        defmodule unquote(module_name) do
+          def hello() do
+            :world
+          end
+        end
+      end
+
+    ast
+  end
+end

--- a/test/rewrite/project_test.exs
+++ b/test/rewrite/project_test.exs
@@ -17,7 +17,7 @@ defmodule Rewrite.ProjectTest do
     test "creates a project from wildcard" do
       inputs = ["test/fixtures/source/*.ex"]
       assert project = Project.read!(inputs)
-      assert Enum.count(project.sources) == 3
+      assert Enum.count(project.sources) == 4
     end
 
     test "creates a project from wildcards" do
@@ -29,7 +29,7 @@ defmodule Rewrite.ProjectTest do
     test "creates a project from glob" do
       inputs = [GlobEx.compile!("test/fixtures/source/*.ex")]
       assert project = Project.read!(inputs)
-      assert Enum.count(project.sources) == 3
+      assert Enum.count(project.sources) == 4
     end
 
     test "creates a project from globs" do

--- a/test/rewrite/source_test.exs
+++ b/test/rewrite/source_test.exs
@@ -330,6 +330,12 @@ defmodule Rewrite.SourceTest do
       assert Source.modules(source, 2) == [TheApp.Simple]
       assert Source.modules(source, 3) == [AnApp.Simple]
     end
+
+    test "returns the modules after filtering out ast" do
+      path = "test/fixtures/source/module_ast_contained.ex"
+      source = Source.read!(path)
+      assert Source.modules(source, 1) == [ModuleAstContained]
+    end
   end
 
   describe "put_private/3" do


### PR DESCRIPTION
<img width="955" alt="image" src="https://user-images.githubusercontent.com/12830256/221360347-3ccdc204-2a29-4209-9db4-2dc3a15a4713.png">

`Rewrite.Source.concat/1` can not match when a `defmodule unquote(something) do` is in a [file](https://github.com/scottming/rewrite/blob/fix-module-concat/test/fixtures/source/module_ast_contained.ex)

So I just added a fallback match function and filter out the last.

