### PR TITLE
improvement: honor import_deps in formatter_opts

### DIFF
--- a/lib/rewrite/source/ex.ex
+++ b/lib/rewrite/source/ex.ex
@@ -410,7 +410,7 @@ defmodule Rewrite.Source.Ex do
     end
   end
 
-  defp assert_valid_dep_and_fetch_path(_dep, _deps_paths) do
+  defp fetch_valid_dep_path(_dep, _deps_paths) do
     nil
   end
 

--- a/lib/rewrite/source/ex.ex
+++ b/lib/rewrite/source/ex.ex
@@ -387,7 +387,8 @@ defmodule Rewrite.Source.Ex do
       deps_paths = Mix.Project.deps_paths()
 
       for dep <- deps,
-          dep_path = assert_valid_dep_and_fetch_path(dep, deps_paths),
+          dep_path = fetch_valid_dep_path(dep, deps_paths),
+          !is_nil(dep_path),
           dep_dot_formatter = Path.join(dep_path, ".formatter.exs"),
           File.regular?(dep_dot_formatter),
           dep_opts = eval_file_with_keyword_list(dep_dot_formatter),
@@ -399,20 +400,18 @@ defmodule Rewrite.Source.Ex do
     defp eval_deps_opts(_), do: []
   end
 
-  defp assert_valid_dep_and_fetch_path(dep, deps_paths) when is_atom(dep) do
+  defp fetch_valid_dep_path(dep, deps_paths) when is_atom(dep) do
     with %{^dep => path} <- deps_paths,
          true <- File.dir?(path) do
       path
     else
       _ ->
-        raise "Unknown dependency #{inspect(dep)} given to :import_deps in the formatter configuration. " <>
-                "Make sure the dependency is listed in your mix.exs for environment #{inspect(Mix.env())} " <>
-                "and you have run \"mix deps.get\""
+        nil
     end
   end
 
-  defp assert_valid_dep_and_fetch_path(dep, _deps_paths) do
-    raise "Dependencies in :import_deps should be atoms, got: #{inspect(dep)}"
+  defp assert_valid_dep_and_fetch_path(_dep, _deps_paths) do
+    nil
   end
 
   defp eval_file_with_keyword_list(path) do

--- a/lib/rewrite/source/ex.ex
+++ b/lib/rewrite/source/ex.ex
@@ -349,7 +349,7 @@ defmodule Rewrite.Source.Ex do
         |> update_formatter_opts(opts)
         |> eval_deps()
 
-      code = Sourceror.to_string(quoted, Keyword.take(opts, [:locals_without_parens]))
+      code = Sourceror.to_string(quoted, opts)
 
       code =
         opts
@@ -378,26 +378,22 @@ defmodule Rewrite.Source.Ex do
     formatter_opts
   end
 
-  if Code.ensure_loaded?(Mix.Project) do
-    defp eval_deps_opts([]) do
-      []
-    end
+  defp eval_deps_opts([]) do
+    []
+  end
 
-    defp eval_deps_opts(deps) do
-      deps_paths = Mix.Project.deps_paths()
+  defp eval_deps_opts(deps) do
+    deps_paths = Mix.Project.deps_paths()
 
-      for dep <- deps,
-          dep_path = fetch_valid_dep_path(dep, deps_paths),
-          !is_nil(dep_path),
-          dep_dot_formatter = Path.join(dep_path, ".formatter.exs"),
-          File.regular?(dep_dot_formatter),
-          dep_opts = eval_file_with_keyword_list(dep_dot_formatter),
-          parenless_call <- dep_opts[:export][:locals_without_parens] || [],
-          uniq: true,
-          do: parenless_call
-    end
-  else
-    defp eval_deps_opts(_), do: []
+    for dep <- deps,
+        dep_path = fetch_valid_dep_path(dep, deps_paths),
+        !is_nil(dep_path),
+        dep_dot_formatter = Path.join(dep_path, ".formatter.exs"),
+        File.regular?(dep_dot_formatter),
+        dep_opts = eval_file_with_keyword_list(dep_dot_formatter),
+        parenless_call <- dep_opts[:export][:locals_without_parens] || [],
+        uniq: true,
+        do: parenless_call
   end
 
   defp fetch_valid_dep_path(dep, deps_paths) when is_atom(dep) do


### PR DESCRIPTION
👋 Was able to get everything sorted from #33, with the primary exception of needing to support the `import_deps` option of `.formatter.exs` files. By doing this work here, we ensure that it is honored if set when formatting files 🥳 