### PR TITLE
Add option to ignore unknown deps in formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 1.0.0 - 2024/11/03
+## 1.0.1 - 2024/11/03
 
 + Set `locals_for_parens` to `[]` for `Sourceror.to_string/2` if not set, to 
   prevent Sourceror from trying to fetch `locals_for_parens`.
++ Add option `:ignore_unknown_deps` to `DotFormatter.read/2` and friends.
 
 ## 1.0.0 - 2024/11/01
 

--- a/lib/rewrite/dot_formatter.ex
+++ b/lib/rewrite/dot_formatter.ex
@@ -1308,11 +1308,15 @@ defmodule Rewrite.DotFormatter do
 
     result =
       Enum.reduce_while(deps, [], fn dep, acc ->
-        with {:ok, path} <- Map.fetch(paths, dep) do
-          {:cont, [{dep, Path.join(path, @default_dot_formatter)} | acc]}
-        else
-          :error when ignore_unknown_deps -> {:cont, acc}
-          :error -> {:halt, %DotFormatterError{reason: {:dep_not_found, dep}}}
+        case Map.fetch(paths, dep) do
+          {:ok, path} ->
+            {:cont, [{dep, Path.join(path, @default_dot_formatter)} | acc]}
+
+          :error when ignore_unknown_deps ->
+            {:cont, acc}
+
+          :error ->
+            {:halt, %DotFormatterError{reason: {:dep_not_found, dep}}}
         end
       end)
 

--- a/lib/rewrite/dot_formatter.ex
+++ b/lib/rewrite/dot_formatter.ex
@@ -1308,14 +1308,11 @@ defmodule Rewrite.DotFormatter do
 
     result =
       Enum.reduce_while(deps, [], fn dep, acc ->
-        case Map.fetch(paths, dep) do
-          :error ->
-            if ignore_unknown_deps,
-              do: {:cont, acc},
-              else: {:halt, %DotFormatterError{reason: {:dep_not_found, dep}}}
-
-          {:ok, path} ->
-            {:cont, [{dep, Path.join(path, @default_dot_formatter)} | acc]}
+        with {:ok, path} <- Map.fetch(paths, dep) do
+          {:cont, [{dep, Path.join(path, @default_dot_formatter)} | acc]}
+        else
+          :error when ignore_unknown_deps -> {:cont, acc}
+          :error -> {:halt, %DotFormatterError{reason: {:dep_not_found, dep}}}
         end
       end)
 

--- a/lib/rewrite/dot_formatter.ex
+++ b/lib/rewrite/dot_formatter.ex
@@ -91,6 +91,9 @@ defmodule Rewrite.DotFormatter do
 
     * `replace_plugins` - a list of `{old, new}` tuples to replace plugins in
       the formatter.
+
+    * `ignore_unknown_deps` - ingores unknown dependencies in `:import_deps` 
+      when set to `true`. Defaults to `false`.
   """
   @spec read(rewrite :: Rewrite.t() | keyword() | nil, keyword()) ::
           {:ok, t()} | {:error, DotFormatterError.t()}
@@ -112,7 +115,7 @@ defmodule Rewrite.DotFormatter do
   defp eval(rewrite, opts, path, dot_formatter_path, term, timestamp) do
     with {:ok, term} <- validate(term, dot_formatter_path, path),
          {:ok, dot_formatter} <- new(term, dot_formatter_path, timestamp),
-         {:ok, dot_formatter} <- eval_deps(dot_formatter),
+         {:ok, dot_formatter} <- eval_deps(dot_formatter, opts),
          {:ok, dot_formatter} <- eval_subs(dot_formatter, rewrite, opts),
          {:ok, dot_formatter} <- update_plugins(dot_formatter, opts) do
       load_plugins(dot_formatter)
@@ -1054,7 +1057,7 @@ defmodule Rewrite.DotFormatter do
           {formatter_opts, [plugin | plugins]}
         end
 
-      # If not set, explicitly set locals_without_parens to [] to prevent 
+      # If not set, explicitly set locals_without_parens to [] to prevent
       # Sourceror from trying to fetch locals_without_parens.
       formatter_opts = Keyword.put_new(formatter_opts, :locals_without_parens, [])
 
@@ -1079,7 +1082,7 @@ defmodule Rewrite.DotFormatter do
     fn input ->
       formatter_opts = Keyword.put(formatter_opts, :quoted_to_algebra, &Code.quoted_to_algebra/2)
 
-      # If not set, explicitly set locals_without_parens to [] to prevent 
+      # If not set, explicitly set locals_without_parens to [] to prevent
       # Sourceror from trying to fetch locals_without_parens.
       formatter_opts = Keyword.put_new(formatter_opts, :locals_without_parens, [])
 
@@ -1128,10 +1131,10 @@ defmodule Rewrite.DotFormatter do
     end
   end
 
-  defp eval_deps(%{import_deps: nil} = dot_formatter), do: {:ok, dot_formatter}
+  defp eval_deps(%{import_deps: nil} = dot_formatter, _opts), do: {:ok, dot_formatter}
 
-  defp eval_deps(%{import_deps: deps} = dot_formatter) do
-    with {:ok, deps_paths} <- deps_paths(deps),
+  defp eval_deps(%{import_deps: deps} = dot_formatter, opts) do
+    with {:ok, deps_paths} <- deps_paths(deps, opts),
          {:ok, locals_without_parens} <- locals_without_parens(deps_paths) do
       dot_formatter =
         Map.update!(dot_formatter, :locals_without_parens, fn list ->
@@ -1299,14 +1302,20 @@ defmodule Rewrite.DotFormatter do
     end
   end
 
-  defp deps_paths(deps) do
+  defp deps_paths(deps, opts) do
     paths = Mix.Project.deps_paths()
+    ignore_unknown_deps = Keyword.get(opts, :ignore_unknown_deps, false)
 
     result =
       Enum.reduce_while(deps, [], fn dep, acc ->
         case Map.fetch(paths, dep) do
-          :error -> {:halt, %DotFormatterError{reason: {:dep_not_found, dep}}}
-          {:ok, path} -> {:cont, [{dep, Path.join(path, @default_dot_formatter)} | acc]}
+          :error ->
+            if ignore_unknown_deps,
+              do: {:cont, acc},
+              else: {:halt, %DotFormatterError{reason: {:dep_not_found, dep}}}
+
+          {:ok, path} ->
+            {:cont, [{dep, Path.join(path, @default_dot_formatter)} | acc]}
         end
       end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Rewrite.MixProject do
   use Mix.Project
 
-  @version "1.0.0"
+  @version "1.0.1"
   @source_url "https://github.com/hrzndhrn/rewrite"
 
   def project do

--- a/test/rewrite/dot_formatter_test.exs
+++ b/test/rewrite/dot_formatter_test.exs
@@ -2475,29 +2475,8 @@ defmodule Rewrite.DotFormatterTest do
       end
     end
 
-    @tag :project
     test "validates dependencies in :import_deps", context do
       in_tmp context do
-        write!(
-          ".formatter.exs": """
-          [import_deps: [:my_dep]]
-          """
-        )
-
-        assert {:error,
-                %Rewrite.DotFormatterError{
-                  reason: {:dep_not_found, :my_dep},
-                  path: "deps/my_dep/.formatter.exs"
-                } = error} = DotFormatter.read()
-
-        message = """
-        Unknown dependency :my_dep given to :import_deps in the formatter \
-        configuration. Make sure the dependency is listed in your mix.exs for \
-        environment :dev and you have run "mix deps.get"\
-        """
-
-        assert Exception.message(error) == message
-
         write!(
           ".formatter.exs": """
           [import_deps: [:nonexistent_dep]]
@@ -2516,6 +2495,18 @@ defmodule Rewrite.DotFormatterTest do
         """
 
         assert Exception.message(error) == message
+      end
+    end
+
+    test "ignores unknown dependencies in :import_deps", context do
+      in_tmp context do
+        write!(
+          ".formatter.exs": """
+          [import_deps: [:nonexistent_dep]]
+          """
+        )
+
+        assert {:ok, _dot_formatter} = DotFormatter.read(ignore_unknown_deps: true)
       end
     end
 


### PR DESCRIPTION
Fixes for #39 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `:ignore_unknown_deps` option to enhance dependency management in the DotFormatter.
	- Updated behavior for `locals_for_parens` to default to an empty list if not defined.

- **Bug Fixes**
	- Improved error handling for unknown dependencies, allowing the formatter to operate without errors.

- **Tests**
	- Added new tests to verify the handling of unknown dependencies with the `ignore_unknown_deps` option.
	- Modified existing tests to reflect updated behavior regarding dependency validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->