### PR TITLE
Add exclude option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 - 2024/11/09
+
++ Adde `:exclude` option to `Rewrite.new!/2` and `Rewrite.read!/2`.
+
 ## 1.0.1 - 2024/11/03
 
 + Set `locals_for_parens` to `[]` for `Sourceror.to_string/2` if not set, to 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0 - 2024/11/09
 
-+ Adde `:exclude` option to `Rewrite.new!/2` and `Rewrite.read!/2`.
++ Added `:exclude` option to `Rewrite.new!/2` and `Rewrite.read!/2`.
 
 ## 1.0.1 - 2024/11/03
 

--- a/lib/rewrite.ex
+++ b/lib/rewrite.ex
@@ -125,7 +125,7 @@ defmodule Rewrite do
       `force: true` updates and issues for an already existing source are 
       deleted.
 
-    * 'exclude' - a list of paths and/or glob expressions to exclude sources 
+    * `:exclude` - a list of paths and/or glob expressions to exclude sources 
       from the project. The option also accepts a predicate function which is 
       called for each source path.  The exclusion takes place before the file is 
       read.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Rewrite.MixProject do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.1.0"
   @source_url "https://github.com/hrzndhrn/rewrite"
 
   def project do

--- a/test/rewrite_test.exs
+++ b/test/rewrite_test.exs
@@ -316,6 +316,7 @@ defmodule RewriteTest do
 
         assert project = Rewrite.new!("**", exclude: ["foo.ex", ~g/baz*/])
         assert project.sources |> Map.keys() == ["bar.ex"]
+        assert project.excluded == ["foo.ex", "baz.ex"]
       end
     end
 
@@ -329,6 +330,7 @@ defmodule RewriteTest do
 
         assert project = Rewrite.new!("**", exclude: exclude?)
         assert project.sources |> Map.keys() == ["bar.ex"]
+        assert project.excluded == ["foo.ex"]
       end
     end
   end

--- a/test/rewrite_test.exs
+++ b/test/rewrite_test.exs
@@ -1,11 +1,12 @@
 defmodule RewriteTest do
   use RewriteCase, async: false
 
-  alias Rewrite.Source
+  import GlobEx.Sigils
 
   alias Rewrite.DotFormatter
   alias Rewrite.DotFormatterError
   alias Rewrite.Error
+  alias Rewrite.Source
   alias Rewrite.SourceError
   alias Rewrite.UpdateError
 
@@ -303,6 +304,31 @@ defmodule RewriteTest do
 
       assert_raise SyntaxError, fn ->
         Rewrite.new!(inputs)
+      end
+    end
+
+    @tag :tmp_dir
+    test "excludes files by path and glob", context do
+      in_tmp context do
+        File.write!("foo.ex", ":foo")
+        File.write!("bar.ex", ":bar")
+        File.write!("baz.ex", ":baz")
+
+        assert project = Rewrite.new!("**", exclude: ["foo.ex", ~g/baz*/])
+        assert project.sources |> Map.keys() == ["bar.ex"]
+      end
+    end
+
+    @tag :tmp_dir
+    test "excludes file by function", context do
+      in_tmp context do
+        File.write!("foo.ex", ":foo")
+        File.write!("bar.ex", ":bar")
+
+        exclude? = fn path -> path == "foo.ex" end
+
+        assert project = Rewrite.new!("**", exclude: exclude?)
+        assert project.sources |> Map.keys() == ["bar.ex"]
       end
     end
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes for Version 1.1.0

- **New Features**
  - Introduced the `:exclude` option for `Rewrite.new!/2` and `Rewrite.read!/2`, allowing users to exclude specific paths or files from processing.

- **Bug Fixes**
  - Enhanced error handling during source operations remains consistent with previous versions.

- **Documentation**
  - Updated documentation to include details about the new `:exclude` option for relevant functions.

- **Tests**
  - Added tests to verify the functionality of file exclusions based on paths and glob patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->