### PR TITLE
Clean up extra_applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.2 - dev
+
++ Clean up `extra_applications`.
+
 ## 1.1.1 - 2024/11/15
 
 + Add option `ignore_missing_sub_formatters` in `Rewrite.DotFormatter.read/2` 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Rewrite.MixProject do
   use Mix.Project
 
-  @version "1.1.1"
+  @version "1.1.2"
   @source_url "https://github.com/hrzndhrn/rewrite"
 
   def project do
@@ -25,7 +25,7 @@ defmodule Rewrite.MixProject do
 
   def application do
     [
-      extra_applications: [:logger, :mix, :crypto],
+      extra_applications: [:logger],
       mod: {Rewrite.Application, []}
     ]
   end
@@ -52,6 +52,7 @@ defmodule Rewrite.MixProject do
   defp dialyzer do
     [
       ignore_warnings: ".dialyzer_ignore.exs",
+      plt_add_apps: [:mix],
       plt_file: {:no_warn, "test/support/plts/dialyzer.plt"},
       flags: [:unmatched_returns]
     ]


### PR DESCRIPTION
closes #43 

The `:crypto` app is no longer in use and can be removed. The `:mix` app was only added for `mix dialyzer` and is now set with `plt_add_aps` key in the dialyzer options.