### PR TITLE
Use elixirc_options instead of deprecated xref: [exclude: ...]

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Rewrite.MixProject do
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       test_ignore_filters: [~r'test/support/.*', ~r'test/fixtures/.*'],
-      xref: [exclude: [FreedomFormatter.Formatter]]
+      elixirc_options: [no_warn_undefined: [FreedomFormatter.Formatter]]
     ]
   end
 


### PR DESCRIPTION
Replaces the deprecated `xref: [exclude: [...]]` option in `mix.exs` with the recommended `elixirc_options: [no_warn_undefined: [...]]`, introduced in Elixir 1.20.

Resolves the following warning during `mix compile`:

> warning: "xref: [exclude: ...]" in your mix.exs file is deprecated, instead use: "elixirc_options: [no_warn_undefined: ...]"